### PR TITLE
ci: set web 404 fallback to `index.html`

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -36,7 +36,11 @@ jobs:
 
       # TODO: nx computation caching?
       - name: Build apps/web
-        run: npx nx run web:build:production
+        run: |
+          npx nx run web:build:production && \
+          # include `_redirect` file in `dist`
+          # https://docs.netlify.com/routing/redirects/
+          cp ./devops/_redirects ./dist/apps/web/_redirects
 
       # Upload build artifacts so it can be downloaded from a different job/workflow
       # since we can't define an approval step within a jobs step(s)...

--- a/devops/_redirects
+++ b/devops/_redirects
@@ -1,0 +1,2 @@
+# 404 fallback to index.html
+/* /index.html 404


### PR DESCRIPTION
## Overview

Currently, whenever we try to deep link to some url in our app, we end up getting presented with a 404 not found. This is well explained by react router:

> If you use routers that use the HTML5 [pushState history API](https://developer.mozilla.org/en-US/docs/Web/API/History_API#Adding_and_modifying_history_entries) under the hood (for example, [React Router](https://github.com/ReactTraining/react-router) with browserHistory), many static file servers will fail. For example, if you used React Router with a route for /todos/42, the development server will respond to localhost:3000/todos/42 properly, but an Express serving a production build as above will not.
>
> This is because when there is a fresh page load for a /todos/42, the server looks for the file build/todos/42 and does not find it. The server needs to be configured to respond to a request to /todos/42 by serving index.html

This PR essentially applies the above solution and adds redirect rules so that any routes that responds with a 404 will fallback to being served the `/index.html`

## WOMP

_`_redirects` file is included in the build outputs `dist` dir_

<img width="412" alt="image" src="https://user-images.githubusercontent.com/23093814/186657190-66fbbff9-c819-4e29-905e-219c16bae44c.png">

## WOMM

https://user-images.githubusercontent.com/23093814/186657399-31c64552-539f-4384-b8aa-fa55dbec20e8.mov